### PR TITLE
fix: Explicity setting `use_async` to False while adding langchain_factory decorator

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,7 @@ You are an artificial intelligence assistant. The assistant gives helpful, detai
 """
 
 
-@cl.langchain_factory
+@cl.langchain_factory(use_async=False)
 def factory():
     prompt = PromptTemplate(template=template, input_variables=["question"])
     llm_chain = LLMChain(prompt=prompt, llm=llm, verbose=True)


### PR DESCRIPTION
### Why?
- ChainLLM currently supports only the following LLMs for Async API: OpenAI, PromptLayerOpenAI, ChatOpenAI and Anthropic
- `use_async` is a required parameter while adding the `langchain_factory` decorator though (otherwise you receive `ValueError: langchain_factory use_async parameter is required` error)
- Setting `use_async` as `True` throws: `Async generation not implemented for this LLM`:
<img width="641" alt="Screenshot 2023-06-18 at 01 31 26" src="https://github.com/menloparklab/falcon-langchain/assets/1212811/b5d4a966-2f39-44ee-bf36-4bca23d82ce3">

- Setting `use_async` to `False` fixes the problem:
<img width="1084" alt="Screenshot 2023-06-18 at 02 02 48" src="https://github.com/menloparklab/falcon-langchain/assets/1212811/e0dc4e21-8641-4baa-800e-e9b90e443827">
